### PR TITLE
added missing quotes in coupled/atmos_model.F90

### DIFF
--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -893,7 +893,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, &
 !-----------------------------------------------------------------------
 !---- print version number to logfile ----
 
-   call write_version_number ("atmos_model_mod, version)
+   call write_version_number ("atmos_model_mod", version)
 !  write the namelist to a log file
    if (mpp_pe() == mpp_root_pe()) then
       unit = stdlog( )


### PR DESCRIPTION
**Description**
Fixes missing quote in coupled/atmos_model.F90

Fixes # (issue)

**How Has This Been Tested?**
Compile tests on gaea

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

