### PR TITLE
bugfix in SHiELD version and solo model updates

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -621,13 +621,13 @@ subroutine update_atmos_model_state (Atmos)
     call get_time (Atmos%Time - diag_time, isec)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
 
+    time_int = real(isec)
     if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. (IPD_Control%kdt == 1 .and. first_time_step) ) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
     endif
     if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. first_time_step) then
-      time_int = real(isec)
       if(Atmos%iau_offset > zero) then
         if( time_int - Atmos%iau_offset*3600. > zero ) then
           time_int = time_int - Atmos%iau_offset*3600.

--- a/solo/atmos_model.F90
+++ b/solo/atmos_model.F90
@@ -25,31 +25,12 @@ program atmos_model
 !
 !-----------------------------------------------------------------------
 
-use fms_affinity_mod, only: fms_affinity_set
-use          mpp_mod, only: input_nml_file
-use   atmosphere_mod, only: atmosphere_init, atmosphere_end, atmosphere, atmosphere_domain
-use time_manager_mod, only: time_type, set_time, get_time,  &
-                            operator(+), operator (<), operator (>), &
-                            operator (/=), operator (/), operator (*), &
-                            set_calendar_type, set_date, get_date, days_in_year, days_in_month, &
-                            NO_CALENDAR, THIRTY_DAY_MONTHS, NOLEAP, JULIAN, GREGORIAN, INVALID_CALENDAR
-use          fms_mod, only: check_nml_error,                &
-                            error_mesg, FATAL, WARNING,                 &
-                            mpp_pe, mpp_root_pe, fms_init, fms_end,     &
-                            stdlog, stdout, write_version_number,       &
-                            lowercase,               &
-                            mpp_clock_id, mpp_clock_begin,              &
-                            mpp_clock_end, CLOCK_COMPONENT
-use       fms_io_mod, only: fms_io_exit
-use      fms2_io_mod, only: file_exists, ascii_read
-use  mpp_mod,         only: mpp_set_current_pelist
-use  mpp_domains_mod, only: domain2d
-use diag_manager_mod, only: diag_manager_init, diag_manager_end, get_base_date
+use FMS
+use FMSconstants
+use atmosphere_mod, only: atmosphere_init, atmosphere_end, atmosphere, atmosphere_domain
 
-use  field_manager_mod, only: MODEL_ATMOS
-use tracer_manager_mod, only: register_tracers
-use       memutils_mod, only: print_memuse_stats
-use   constants_mod,    only: SECONDS_PER_HOUR,  SECONDS_PER_MINUTE
+!--- FMS old io
+use fms_io_mod, only: fms_io_exit!< This can't be removed until fms_io is not used at all
 
 implicit none
 
@@ -145,7 +126,7 @@ contains
     integer :: stdout_unit !< Unit of stdout file
     integer :: ascii_unit  !< Unit of a dummy ascii file
     character(len=:), dimension(:), allocatable :: restart_file !< Restart file saved as a string
-    integer :: ierr, io, logunit
+    integer :: ierr, io, logunit, dt_size
     integer :: ntrace, ntprog, ntdiag, ntfamily
     integer :: date(6)
     type (time_type) :: Run_length
@@ -312,24 +293,35 @@ contains
 !-----------------------------------------------------------------------
 !------ initialize atmospheric model ------
 
-!$    call omp_set_num_threads(atmos_nthreads)
-      call fms_affinity_set('Atmos Program', use_hyper_thread, atmos_nthreads)
-      if (mpp_pe() .eq. mpp_root_pe()) then
-        stdout_unit=stdout()
-        write(stdout_unit,*) ' starting ',atmos_nthreads,' OpenMP threads per MPI-task'
-        call flush(stdout_unit)
-      endif
+!$ call omp_set_num_threads(atmos_nthreads)
+   call fms_affinity_set('Atmos Program', use_hyper_thread, atmos_nthreads)
+   if (mpp_pe() .eq. mpp_root_pe()) then
+     stdout_unit=stdout()
+     write(stdout_unit,*) ' starting ',atmos_nthreads,' OpenMP threads per MPI-task'
+     call flush(stdout_unit)
+   endif
 
-      call atmosphere_init (Time_init, Time, Time_step_atmos)
-      call atmosphere_domain(atmos_domain)
+   call atmosphere_init (Time_init, Time, Time_step_atmos)
+   call atmosphere_domain(atmos_domain)
+
+   if (file_exists('data_table')) then
+     inquire(file='data_table', size=dt_size)
+     if (dt_size > 0) then
+       call data_override_init(Atm_domain_in = atmos_domain)
+     else
+       call error_mesg ('program atmos_model', 'empty data table, skipping data override init', NOTE)
+     endif
+   else
+     call error_mesg ('program atmos_model', 'no data table, skipping data override init', NOTE)
+   endif
 
 !-----------------------------------------------------------------------
 !   open and close dummy file in restart dir to check if dir exists
-      call mpp_set_current_pelist()
-    if ( mpp_pe().EQ.mpp_root_pe() ) then
-       open(newunit = ascii_unit, file='RESTART/file', status='replace', form='formatted')
-       close(ascii_unit,status="delete")
-    endif
+   call mpp_set_current_pelist()
+   if ( mpp_pe().EQ.mpp_root_pe() ) then
+     open(newunit = ascii_unit, file='RESTART/file', status='replace', form='formatted')
+     close(ascii_unit,status="delete")
+   endif
 
 !  ---- terminate timing ----
    call mpp_clock_end (id_init)

--- a/solo/atmos_model.F90
+++ b/solo/atmos_model.F90
@@ -63,11 +63,9 @@ implicit none
 !-----------------------------------------------------------------------
    type(domain2d), save :: atmos_domain  ! This variable must be treated as read-only
 !-----------------------------------------------------------------------
-   character(len=17) :: calendar = '                 '  !< The calendar type used by the current integration.  Valid values are
+   character(len=17) :: calendar = 'no_calendar      '  !< The calendar type used by the current integration.  Valid values are
                                                         !! consistent with the time_manager module: 'gregorian', 'julian',
-                                                        !! 'noleap', or 'thirty_day'. The value 'no_calendar' cannot be used
-                                                        !! because the time_manager's date !! functions are used.
-                                                        !! All values must be lower case.
+                                                        !! 'noleap', or 'thirty_day'. All values must be lower case.
    integer, dimension(4) :: current_time = (/ 0, 0, 0, 0/) !< The current time integration starts with (DD,HH,MM,SS)
    integer :: years=0    !< Number of years the current integration will be run
    integer :: months=0   !< Number of months the current integration will be run


### PR DESCRIPTION
**Description**
Fixes an uninitialized variable bug in SHiELD version
In the solo driver:
 - adds data_override_init capability
 - cleans up some minor spacing issues 
 - cleans up fortran module usage

Fixes # (issue)

**How Has This Been Tested?**
Solo model tests for the dycore have been run along with SHiELD tests.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

