### PR TITLE
Bug fixes and data_override logic updates

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -621,13 +621,13 @@ subroutine update_atmos_model_state (Atmos)
     call get_time (Atmos%Time - diag_time, isec)
     call get_time (Atmos%Time - Atmos%Time_init, seconds)
 
+    time_int = real(isec)
     if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. (IPD_Control%kdt == 1 .and. first_time_step) ) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
     endif
     if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. first_time_step) then
-      time_int = real(isec)
       if(Atmos%iau_offset > zero) then
         if( time_int - Atmos%iau_offset*3600. > zero ) then
           time_int = time_int - Atmos%iau_offset*3600.

--- a/solo/atmos_model.F90
+++ b/solo/atmos_model.F90
@@ -25,31 +25,12 @@ program atmos_model
 !
 !-----------------------------------------------------------------------
 
-use fms_affinity_mod, only: fms_affinity_set
-use          mpp_mod, only: input_nml_file
-use   atmosphere_mod, only: atmosphere_init, atmosphere_end, atmosphere, atmosphere_domain
-use time_manager_mod, only: time_type, set_time, get_time,  &
-                            operator(+), operator (<), operator (>), &
-                            operator (/=), operator (/), operator (*), &
-                            set_calendar_type, set_date, get_date, days_in_year, days_in_month, &
-                            NO_CALENDAR, THIRTY_DAY_MONTHS, NOLEAP, JULIAN, GREGORIAN, INVALID_CALENDAR
-use          fms_mod, only: check_nml_error,                &
-                            error_mesg, FATAL, WARNING,                 &
-                            mpp_pe, mpp_root_pe, fms_init, fms_end,     &
-                            stdlog, stdout, write_version_number,       &
-                            lowercase,               &
-                            mpp_clock_id, mpp_clock_begin,              &
-                            mpp_clock_end, CLOCK_COMPONENT
-use       fms_io_mod, only: fms_io_exit
-use      fms2_io_mod, only: file_exists, ascii_read
-use  mpp_mod,         only: mpp_set_current_pelist
-use  mpp_domains_mod, only: domain2d
-use diag_manager_mod, only: diag_manager_init, diag_manager_end, get_base_date
+use FMS
+use FMSconstants
+use atmosphere_mod, only: atmosphere_init, atmosphere_end, atmosphere, atmosphere_domain
 
-use  field_manager_mod, only: MODEL_ATMOS
-use tracer_manager_mod, only: register_tracers
-use       memutils_mod, only: print_memuse_stats
-use   constants_mod,    only: SECONDS_PER_HOUR,  SECONDS_PER_MINUTE
+!--- FMS old io
+use fms_io_mod, only: fms_io_exit!< This can't be removed until fms_io is not used at all
 
 implicit none
 
@@ -82,11 +63,9 @@ implicit none
 !-----------------------------------------------------------------------
    type(domain2d), save :: atmos_domain  ! This variable must be treated as read-only
 !-----------------------------------------------------------------------
-   character(len=17) :: calendar = '                 '  !< The calendar type used by the current integration.  Valid values are
+   character(len=17) :: calendar = 'no_calendar      '  !< The calendar type used by the current integration.  Valid values are
                                                         !! consistent with the time_manager module: 'gregorian', 'julian',
-                                                        !! 'noleap', or 'thirty_day'. The value 'no_calendar' cannot be used
-                                                        !! because the time_manager's date !! functions are used.
-                                                        !! All values must be lower case.
+                                                        !! 'noleap', or 'thirty_day'. All values must be lower case.
    integer, dimension(4) :: current_time = (/ 0, 0, 0, 0/) !< The current time integration starts with (DD,HH,MM,SS)
    integer :: years=0    !< Number of years the current integration will be run
    integer :: months=0   !< Number of months the current integration will be run
@@ -312,24 +291,26 @@ contains
 !-----------------------------------------------------------------------
 !------ initialize atmospheric model ------
 
-!$    call omp_set_num_threads(atmos_nthreads)
-      call fms_affinity_set('Atmos Program', use_hyper_thread, atmos_nthreads)
-      if (mpp_pe() .eq. mpp_root_pe()) then
-        stdout_unit=stdout()
-        write(stdout_unit,*) ' starting ',atmos_nthreads,' OpenMP threads per MPI-task'
-        call flush(stdout_unit)
-      endif
+!$ call omp_set_num_threads(atmos_nthreads)
+   call fms_affinity_set('Atmos Program', use_hyper_thread, atmos_nthreads)
+   if (mpp_pe() .eq. mpp_root_pe()) then
+     stdout_unit=stdout()
+     write(stdout_unit,*) ' starting ',atmos_nthreads,' OpenMP threads per MPI-task'
+     call flush(stdout_unit)
+   endif
 
-      call atmosphere_init (Time_init, Time, Time_step_atmos)
-      call atmosphere_domain(atmos_domain)
+   call atmosphere_init (Time_init, Time, Time_step_atmos)
+   call atmosphere_domain(atmos_domain)
+
+   call data_override_init(Atm_domain_in = atmos_domain)
 
 !-----------------------------------------------------------------------
 !   open and close dummy file in restart dir to check if dir exists
-      call mpp_set_current_pelist()
-    if ( mpp_pe().EQ.mpp_root_pe() ) then
-       open(newunit = ascii_unit, file='RESTART/file', status='replace', form='formatted')
-       close(ascii_unit,status="delete")
-    endif
+   call mpp_set_current_pelist()
+   if ( mpp_pe().EQ.mpp_root_pe() ) then
+     open(newunit = ascii_unit, file='RESTART/file', status='replace', form='formatted')
+     close(ascii_unit,status="delete")
+   endif
 
 !  ---- terminate timing ----
    call mpp_clock_end (id_init)

--- a/solo/atmos_model.F90
+++ b/solo/atmos_model.F90
@@ -302,7 +302,8 @@ contains
    call atmosphere_init (Time_init, Time, Time_step_atmos)
    call atmosphere_domain(atmos_domain)
 
-   call data_override_init(Atm_domain_in = atmos_domain)
+   !----- add back in if needed -----
+   !call data_override_init(Atm_domain_in = atmos_domain)
 
 !-----------------------------------------------------------------------
 !   open and close dummy file in restart dir to check if dir exists


### PR DESCRIPTION
**Description**
Fixes a bug in SHiELD/atmos_model for variable initialization.
In solo/atmos_model:
 - updates module use handling 
 - removes outdated logic for data_override_init handling
 - gives calendar an initial value

DEPENDENCY ON [FMS PR #933](https://github.com/NOAA-GFDL/FMS/pull/933)

Fixes # (issue)

**How Has This Been Tested?**
This has been tested in FV3 solo tests to ensure proper handling of data_override_init with no grid_spec and an empty data_table.  The variable initialization bug in SHiELD has been tested in a SHiELD run.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

