### PR TITLE
Fix for invisible first_time_step bug in SHiELD

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -151,7 +151,7 @@ logical :: chksum_debug    = .false.
 logical :: dycore_only     = .false.
 logical :: debug           = .false.
 logical :: sync            = .false.
-logical :: first_time_step = .true.
+logical :: first_time_step = .false.
 logical :: fprint          = .true.
 real, dimension(4096) :: fdiag = 0. ! xic: TODO: this is hard coded, space can run out in some cases. Should make it allocatable.
 logical :: fdiag_override = .false. ! lmh: if true overrides fdiag and fhzer: all quantities are zeroed out after every calcluation, output interval and accumulation/avg/max/min are controlled by diag_manager, fdiag controls output interval only
@@ -627,7 +627,7 @@ subroutine update_atmos_model_state (Atmos)
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
     endif
-    if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. first_time_step) then
+    if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. (IPD_Control%kdt == 1 .and. first_time_step)) then
       if(Atmos%iau_offset > zero) then
         if( time_int - Atmos%iau_offset*3600. > zero ) then
           time_int = time_int - Atmos%iau_offset*3600.


### PR DESCRIPTION
Jan-Huey discovered a nasty bug in the SHiELD driver: if first_time_step is true, then physics diagnostics are written on EVERY timestep. Also, since first_time_step defaults to true, if it is not explicitly set to false, then the problem occurs too, without any indication what is happening.

**Description**
 Jan-Huey discovered a nasty bug in the SHiELD Model driver in atmos_model.F90 . If first_time_step is true, then physics diagnostics are written on EVERY timestep. This creates far more history file output than we want.

But also, since first_time_step defaults to true, if it is not explicitly set to false, then the problem occurs too, without any indication what is happening. This creates a very obscure issue that is hard to debug.


**How Has This Been Tested?**
 Ran a test without atmos_model_nml::first_time_step specified

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included

