### PR TITLE
Deprecated fmsio

### DIFF
--- a/solo/atmos_model.F90
+++ b/solo/atmos_model.F90
@@ -29,9 +29,6 @@ use FMS
 use FMSconstants
 use atmosphere_mod, only: atmosphere_init, atmosphere_end, atmosphere, atmosphere_domain
 
-!--- FMS old io
-use fms_io_mod, only: fms_io_exit!< This can't be removed until fms_io is not used at all
-
 implicit none
 
 !-----------------------------------------------------------------------
@@ -111,7 +108,6 @@ implicit none
 !   ------ end of atmospheric time step loop -----
 
  call atmos_model_end
- call fms_io_exit
  call fms_end
 
 contains


### PR DESCRIPTION
**Description**
There was one final fmsio call remaining in solo/atmos_model.F90.  This PR removes it.

Fixes #20 

**How Has This Been Tested?**
Tested with the SHiELD solo idealized tests with intel on gaea c4.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

