### PR TITLE
Pass the namelist variables from the dycore to the physics during the initialization

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -473,6 +473,8 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
    Init_parm%xlat            => Atmos%lat
    Init_parm%area            => Atmos%area
    Init_parm%tracer_names    => tracer_names
+!--- setup IPD_Control
+   IPD_Control%dycore_hydrostatic = hydro
 
    allocate(Init_parm%input_nml_file, mold=input_nml_file)
    Init_parm%input_nml_file  => input_nml_file

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -370,6 +370,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
   character(len=64) :: filename, filename2, pelist_name
   character(len=132) :: text
   logical :: p_hydro, hydro, fexist
+  logical :: do_inline_mp, do_cosp
   logical, save :: block_message = .true.
   integer :: bdat(8), cdat(8)
   integer :: ntracers
@@ -422,7 +423,8 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
 !-----------------------------------------------------------------------
 !--- before going any further check definitions for 'blocks'
 !-----------------------------------------------------------------------
-   call atmosphere_control_data (isc, iec, jsc, jec, nlev, p_hydro, hydro, tile_num)
+   call atmosphere_control_data (isc, iec, jsc, jec, nlev, p_hydro, hydro, tile_num, &
+                                 do_inline_mp, do_cosp)
    call define_blocks_packed ('atmos_model', Atm_block, isc, iec, jsc, jec, nlev, &
                               blocksize, block_message)
 
@@ -475,6 +477,8 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
    Init_parm%tracer_names    => tracer_names
 !--- setup IPD_Control
    IPD_Control%dycore_hydrostatic = hydro
+   IPD_Control%do_inline_mp = do_inline_mp
+   IPD_Control%do_cosp = do_cosp
 
    allocate(Init_parm%input_nml_file, mold=input_nml_file)
    Init_parm%input_nml_file  => input_nml_file


### PR DESCRIPTION
**Description**
The dynamical core and physics package share some namelist variables. In the current model codebase, these namelist variables are either passed from the dynamical core to the physics package after the initialization or duplicated in the physics package. This produces a potential issue that the physics initialization does not see the dynamical core namelist and leads to errors.

Fixes # (issue)
No issue with this atmos_drivers. We need some code changes in atmos_drivers so that our update of the dynamical core and physics package will work.

**How Has This Been Tested?**
It was tested and the results are expected. The issue has been resolved.

**Checklist:**
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- My changes generate no new warnings
- Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included

