### PR TITLE
Revised type of a few variables

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -475,10 +475,9 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
    Init_parm%xlat            => Atmos%lat
    Init_parm%area            => Atmos%area
    Init_parm%tracer_names    => tracer_names
-!--- setup IPD_Control
-   IPD_Control%dycore_hydrostatic = hydro
-   IPD_Control%do_inline_mp = do_inline_mp
-   IPD_Control%do_cosp = do_cosp
+   Init_parm%hydro           = hydro
+   Init_parm%do_inline_mp    = do_inline_mp
+   Init_parm%do_cosp         = do_cosp
 
    allocate(Init_parm%input_nml_file, mold=input_nml_file)
    Init_parm%input_nml_file  => input_nml_file

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -473,6 +473,8 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
    Init_parm%xlat            => Atmos%lat
    Init_parm%area            => Atmos%area
    Init_parm%tracer_names    => tracer_names
+!--- setup IPD_Control
+   IPD_Control%dycore_hydrostatic = hydro
 
    allocate(Init_parm%input_nml_file, mold=input_nml_file)
    Init_parm%input_nml_file  => input_nml_file

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -370,6 +370,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
   character(len=64) :: filename, filename2, pelist_name
   character(len=132) :: text
   logical :: p_hydro, hydro, fexist
+  logical :: do_inline_mp, do_cosp
   logical, save :: block_message = .true.
   integer :: bdat(8), cdat(8)
   integer :: ntracers
@@ -422,7 +423,8 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
 !-----------------------------------------------------------------------
 !--- before going any further check definitions for 'blocks'
 !-----------------------------------------------------------------------
-   call atmosphere_control_data (isc, iec, jsc, jec, nlev, p_hydro, hydro, tile_num)
+   call atmosphere_control_data (isc, iec, jsc, jec, nlev, p_hydro, hydro, tile_num, &
+                                 do_inline_mp, do_cosp)
    call define_blocks_packed ('atmos_model', Atm_block, isc, iec, jsc, jec, nlev, &
                               blocksize, block_message)
 
@@ -475,6 +477,8 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
    Init_parm%tracer_names    => tracer_names
 !--- setup IPD_Control
    IPD_Control%dycore_hydrostatic = hydro
+   IPD_Control%do_inline_mp = do_inline_mp
+   IPD_Control%do_cosp = do_cosp
 
    allocate(Init_parm%input_nml_file, mold=input_nml_file)
    Init_parm%input_nml_file  => input_nml_file


### PR DESCRIPTION
**Description**
This PR and PR https://github.com/NOAA-GFDL/SHiELD_physics/pull/26 address the following comment from the review of PR https://github.com/NOAA-GFDL/SHiELD_physics/pull/22:

"The designed way to get this information to the physics from outside is to use the GFS_init_type. This type is populated with dycore and other external to the physics information within the atmos_model.F90::atmos_model_init function and it is passed to GFS_Initialize, where it is passed to the Model%init procedure."

Fixes # (issue)

**How Has This Been Tested?**


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

