### PR TITLE
Make `Atm_block`, `IPD_control`, and `IPD_Data` public in `SHiELD/atmos_model.F90`

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -113,6 +113,7 @@ public update_atmos_model_state
 public update_atmos_model_dynamics
 public atmos_model_init, atmos_model_end, atmos_data_type
 public atmos_model_restart
+public Atm_block, IPD_Control, IPD_Data
 !-----------------------------------------------------------------------
 
 !<PUBLICTYPE >


### PR DESCRIPTION
**Description**

This PR makes the `Atm_block`, `IPD_control`, and `IPD_data` structures public in `SHiELD/atmos_model.F90`.  This is needed for interaction within the Python-wrapped version of SHiELD under development starting with ai2cm/SHiELD-wrapper#1.

**How Has This Been Tested?**

These changes have been tested in https://github.com/ai2cm/SHiELD-wrapper/pull/1. The continuous integration setup there builds the fortran model and its dependencies using the SHiELD_build `COMPILE` script, builds the Python wrapper, and runs several tests, including some that leverage interaction with these structures.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included

