### PR TITLE
Passing additional surface variables into the atmospheric model #28

### DIFF
--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -1421,8 +1421,10 @@ subroutine lnd_ice_atm_bnd_type_chksum(id, timestep, bnd_type)
     write(outunit,100) 'lnd_ice_atm_bnd_type%b_star        ',mpp_chksum(bnd_type%b_star         )
     write(outunit,100) 'lnd_ice_atm_bnd_type%q_star        ',mpp_chksum(bnd_type%q_star         )
 #ifndef use_AM3_physics
-    write(outunit,100) 'lnd_ice_atm_bnd_type%shflx         ',mpp_chksum(bnd_type%shflx          )!miz
-    write(outunit,100) 'lnd_ice_atm_bnd_type%lhflx         ',mpp_chksum(bnd_type%lhflx          )!miz
+    if(associated(bnd_type%shflx)) & 
+       write(outunit,100) 'lnd_ice_atm_bnd_type%shflx         ',mpp_chksum(bnd_type%shflx       )!miz
+    if(associated(bnd_type%lhflx)) & 
+       write(outunit,100) 'lnd_ice_atm_bnd_type%lhflx         ',mpp_chksum(bnd_type%lhflx       )!miz
 #endif
     write(outunit,100) 'lnd_ice_atm_bnd_type%wind          ',mpp_chksum(bnd_type%wind           )
     write(outunit,100) 'lnd_ice_atm_bnd_type%thv_atm       ',mpp_chksum(bnd_type%thv_atm        )

--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -537,11 +537,11 @@ subroutine update_atmos_model_down( Surface_boundary, Atmos )
                                   Atmos%gust(is:ie,js:je), &
                                   Rad_flux(1)%control, &
                                   Rad_flux(1)%block(blk), &
-                                  shflx   = Surface_boundary%shflx   (isw:iew,jsw:jew), & ! shflx    required by HanEDMF
-                                  lhflx   = Surface_boundary%lhflx   (isw:iew,jsw:jew), & ! evap     required by HanEDMF
-                                  wind    = Surface_boundary%wind    (isw:iew,jsw:jew), & ! sfc wind required by HanEDMF
-                                  thv_atm = Surface_boundary%thv_atm (isw:iew,jsw:jew), & ! 2m thv   required by HanEDMF
-                                  thv_surf= Surface_boundary%thv_surf(isw:iew,jsw:jew)  ) ! sfc thv  required by HanEDMF
+                                  shflx   = Surface_boundary%shflx   (isw:iew,jsw:jew), & ! shflx    required by NCEP TKE-based EDMF
+                                  lhflx   = Surface_boundary%lhflx   (isw:iew,jsw:jew), & ! evap     required by NCEP TKE-based EDMF
+                                  wind    = Surface_boundary%wind    (isw:iew,jsw:jew), & ! sfc wind required by NCEP TKE-based EDMF
+                                  thv_atm = Surface_boundary%thv_atm (isw:iew,jsw:jew), & ! 2m thv   required by NCEP TKE-based EDMF
+                                  thv_surf= Surface_boundary%thv_surf(isw:iew,jsw:jew)  ) ! sfc thv  required by NCEP TKE-based EDMF
 
     enddo
 

--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -532,18 +532,17 @@ subroutine update_atmos_model_down( Surface_boundary, Atmos )
                                   Surface_boundary%dtaudv       (isw:iew,jsw:jew), &
                                   Surface_boundary%u_flux       (isw:iew,jsw:jew), &
                                   Surface_boundary%v_flux       (isw:iew,jsw:jew), &
-#ifdef use_am5phys
-                                  Surface_boundary%shflx        (isw:iew,jsw:jew), & ! shflx    required by HanEDMF
-                                  Surface_boundary%lhflx        (isw:iew,jsw:jew), & ! evap     required by HanEDMF
-                                  Surface_boundary%wind         (isw:iew,jsw:jew), & ! sfc wind required by HanEDMF
-                                  Surface_boundary%thv_atm      (isw:iew,jsw:jew), & ! 2m thv   required by HanEDMF
-                                  Surface_boundary%thv_surf     (isw:iew,jsw:jew), & ! sfc thv  required by HanEDMF
-#endif
                                   Physics_tendency%block(blk),   &
                                   Atmos%Surf_diff, &
                                   Atmos%gust(is:ie,js:je), &
                                   Rad_flux(1)%control, &
-                                  Rad_flux(1)%block(blk) )
+                                  Rad_flux(1)%block(blk), &
+                                  shflx   = Surface_boundary%shflx   (isw:iew,jsw:jew), & ! shflx    required by HanEDMF
+                                  lhflx   = Surface_boundary%lhflx   (isw:iew,jsw:jew), & ! evap     required by HanEDMF
+                                  wind    = Surface_boundary%wind    (isw:iew,jsw:jew), & ! sfc wind required by HanEDMF
+                                  thv_atm = Surface_boundary%thv_atm (isw:iew,jsw:jew), & ! 2m thv   required by HanEDMF
+                                  thv_surf= Surface_boundary%thv_surf(isw:iew,jsw:jew)  ) ! sfc thv  required by HanEDMF
+
     enddo
 
     call physics_driver_down_endts (1, 1)

--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -205,9 +205,9 @@ type land_ice_atmos_boundary_type
    real, dimension(:,:),   pointer :: q_star         =>null() ! moisture scale
    real, dimension(:,:),   pointer :: shflx          =>null() ! sensible heat flux !miz
    real, dimension(:,:),   pointer :: lhflx          =>null() ! latent heat flux   !miz
-   real, dimension(:,:),   pointer :: wind           =>null() ! surface wind   !ZNT 04/29/2020
-   real, dimension(:,:),   pointer :: thv_atm        =>null() ! surface air theta_v  !ZNT 05/03/2020
-   real, dimension(:,:),   pointer :: thv_surf       =>null() ! surface theta_v      !ZNT 05/03/2020
+   real, dimension(:,:),   pointer :: wind           =>null() ! surface wind
+   real, dimension(:,:),   pointer :: thv_atm        =>null() ! surface air theta_v
+   real, dimension(:,:),   pointer :: thv_surf       =>null() ! surface theta_v
    real, dimension(:,:),   pointer :: rough_mom      =>null() ! surface roughness (used for momentum)
    real, dimension(:,:),   pointer :: frac_open_sea  =>null() ! non-seaice fraction (%)
    real, dimension(:,:,:), pointer :: data           =>null() !collective field for "named" fields above
@@ -533,11 +533,11 @@ subroutine update_atmos_model_down( Surface_boundary, Atmos )
                                   Surface_boundary%u_flux       (isw:iew,jsw:jew), &
                                   Surface_boundary%v_flux       (isw:iew,jsw:jew), &
 #ifdef use_am5phys
-                                  Surface_boundary%shflx        (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
-                                  Surface_boundary%lhflx        (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
-                                  Surface_boundary%wind         (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
-                                  Surface_boundary%thv_atm      (isw:iew,jsw:jew), & ! ZNT 05/03/2020 - Required by HanEDMF
-                                  Surface_boundary%thv_surf     (isw:iew,jsw:jew), & ! ZNT 05/03/2020 - Required by HanEDMF
+                                  Surface_boundary%shflx        (isw:iew,jsw:jew), & ! shflx    required by HanEDMF
+                                  Surface_boundary%lhflx        (isw:iew,jsw:jew), & ! evap     required by HanEDMF
+                                  Surface_boundary%wind         (isw:iew,jsw:jew), & ! sfc wind required by HanEDMF
+                                  Surface_boundary%thv_atm      (isw:iew,jsw:jew), & ! 2m thv   required by HanEDMF
+                                  Surface_boundary%thv_surf     (isw:iew,jsw:jew), & ! sfc thv  required by HanEDMF
 #endif
                                   Physics_tendency%block(blk),   &
                                   Atmos%Surf_diff, &
@@ -1425,9 +1425,9 @@ subroutine lnd_ice_atm_bnd_type_chksum(id, timestep, bnd_type)
     write(outunit,100) 'lnd_ice_atm_bnd_type%shflx         ',mpp_chksum(bnd_type%shflx          )!miz
     write(outunit,100) 'lnd_ice_atm_bnd_type%lhflx         ',mpp_chksum(bnd_type%lhflx          )!miz
 #endif
-    write(outunit,100) 'lnd_ice_atm_bnd_type%wind          ',mpp_chksum(bnd_type%wind           )!ZNT
-    write(outunit,100) 'lnd_ice_atm_bnd_type%thv_atm       ',mpp_chksum(bnd_type%thv_atm        )!ZNT
-    write(outunit,100) 'lnd_ice_atm_bnd_type%thv_surf      ',mpp_chksum(bnd_type%thv_surf       )!ZNT
+    write(outunit,100) 'lnd_ice_atm_bnd_type%wind          ',mpp_chksum(bnd_type%wind           )
+    write(outunit,100) 'lnd_ice_atm_bnd_type%thv_atm       ',mpp_chksum(bnd_type%thv_atm        )
+    write(outunit,100) 'lnd_ice_atm_bnd_type%thv_surf      ',mpp_chksum(bnd_type%thv_surf       )
     write(outunit,100) 'lnd_ice_atm_bnd_type%rough_mom     ',mpp_chksum(bnd_type%rough_mom      )
 !    write(outunit,100) 'lnd_ice_atm_bnd_type%data          ',mpp_chksum(bnd_type%data           )
 

--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -205,6 +205,9 @@ type land_ice_atmos_boundary_type
    real, dimension(:,:),   pointer :: q_star         =>null() ! moisture scale
    real, dimension(:,:),   pointer :: shflx          =>null() ! sensible heat flux !miz
    real, dimension(:,:),   pointer :: lhflx          =>null() ! latent heat flux   !miz
+   real, dimension(:,:),   pointer :: wind           =>null() ! surface wind   !ZNT 04/29/2020
+   real, dimension(:,:),   pointer :: thv_atm        =>null() ! surface air theta_v  !ZNT 05/03/2020
+   real, dimension(:,:),   pointer :: thv_surf       =>null() ! surface theta_v      !ZNT 05/03/2020
    real, dimension(:,:),   pointer :: rough_mom      =>null() ! surface roughness (used for momentum)
    real, dimension(:,:),   pointer :: frac_open_sea  =>null() ! non-seaice fraction (%)
    real, dimension(:,:,:), pointer :: data           =>null() !collective field for "named" fields above
@@ -529,6 +532,11 @@ subroutine update_atmos_model_down( Surface_boundary, Atmos )
                                   Surface_boundary%dtaudv       (isw:iew,jsw:jew), &
                                   Surface_boundary%u_flux       (isw:iew,jsw:jew), &
                                   Surface_boundary%v_flux       (isw:iew,jsw:jew), &
+                                  Surface_boundary%shflx        (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
+                                  Surface_boundary%lhflx        (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
+                                  Surface_boundary%wind         (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
+                                  Surface_boundary%thv_atm      (isw:iew,jsw:jew), & ! ZNT 05/03/2020 - Required by HanEDMF
+                                  Surface_boundary%thv_surf     (isw:iew,jsw:jew), & ! ZNT 05/03/2020 - Required by HanEDMF
                                   Physics_tendency%block(blk),   &
                                   Atmos%Surf_diff, &
                                   Atmos%gust(is:ie,js:je), &
@@ -1415,6 +1423,9 @@ subroutine lnd_ice_atm_bnd_type_chksum(id, timestep, bnd_type)
     write(outunit,100) 'lnd_ice_atm_bnd_type%shflx         ',mpp_chksum(bnd_type%shflx          )!miz
     write(outunit,100) 'lnd_ice_atm_bnd_type%lhflx         ',mpp_chksum(bnd_type%lhflx          )!miz
 #endif
+    write(outunit,100) 'lnd_ice_atm_bnd_type%wind          ',mpp_chksum(bnd_type%wind           )!ZNT
+    write(outunit,100) 'lnd_ice_atm_bnd_type%thv_atm       ',mpp_chksum(bnd_type%thv_atm        )!ZNT
+    write(outunit,100) 'lnd_ice_atm_bnd_type%thv_surf      ',mpp_chksum(bnd_type%thv_surf       )!ZNT
     write(outunit,100) 'lnd_ice_atm_bnd_type%rough_mom     ',mpp_chksum(bnd_type%rough_mom      )
 !    write(outunit,100) 'lnd_ice_atm_bnd_type%data          ',mpp_chksum(bnd_type%data           )
 

--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -532,11 +532,13 @@ subroutine update_atmos_model_down( Surface_boundary, Atmos )
                                   Surface_boundary%dtaudv       (isw:iew,jsw:jew), &
                                   Surface_boundary%u_flux       (isw:iew,jsw:jew), &
                                   Surface_boundary%v_flux       (isw:iew,jsw:jew), &
+#ifdef use_am5phys
                                   Surface_boundary%shflx        (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
                                   Surface_boundary%lhflx        (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
                                   Surface_boundary%wind         (isw:iew,jsw:jew), & ! ZNT 04/29/2020 - Required by HanEDMF
                                   Surface_boundary%thv_atm      (isw:iew,jsw:jew), & ! ZNT 05/03/2020 - Required by HanEDMF
                                   Surface_boundary%thv_surf     (isw:iew,jsw:jew), & ! ZNT 05/03/2020 - Required by HanEDMF
+#endif
                                   Physics_tendency%block(blk),   &
                                   Atmos%Surf_diff, &
                                   Atmos%gust(is:ie,js:je), &

--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -205,9 +205,9 @@ type land_ice_atmos_boundary_type
    real, dimension(:,:),   pointer :: q_star         =>null() ! moisture scale
    real, dimension(:,:),   pointer :: shflx          =>null() ! sensible heat flux !miz
    real, dimension(:,:),   pointer :: lhflx          =>null() ! latent heat flux   !miz
-   real, dimension(:,:),   pointer :: wind           =>null() ! surface wind
-   real, dimension(:,:),   pointer :: thv_atm        =>null() ! surface air theta_v
-   real, dimension(:,:),   pointer :: thv_surf       =>null() ! surface theta_v
+   real, dimension(:,:),   pointer :: wind           =>null() ! absolute wind at lowest atmos model level with gust corrections (w_atm of surface_flux output)
+   real, dimension(:,:),   pointer :: thv_atm        =>null() ! virtual temperature at lowest atmos model level
+   real, dimension(:,:),   pointer :: thv_surf       =>null() ! virtual temperature at the surface
    real, dimension(:,:),   pointer :: rough_mom      =>null() ! surface roughness (used for momentum)
    real, dimension(:,:),   pointer :: frac_open_sea  =>null() ! non-seaice fraction (%)
    real, dimension(:,:,:), pointer :: data           =>null() !collective field for "named" fields above


### PR DESCRIPTION
**Description**
This PR is linked to issue #28 and it depends on issue #92 (#93) of the FMScoupler repository.

A new boundary layer scheme (NCEP TKE-based eddy-diffusivity mass-flux scheme) is being implemented in the prototype-AM5 model, and it requires five additional surface variables (shflx, lhflx, wind, thv_atm, and thv_surf) as inputs. Thus, I would like to add a few lines in the atmos_driver (coupled/atmos_model.F90) to pass these variables into the physics driver. (A "ifdef" statement is added to maintain backward compatibility with AM4's physics driver).

**How Has This Been Tested?**
The AM4 8-day 'basic' run with my **updated FMScoupler and atmos_drivers** can bitwise reproduce the results with those run with the default code. This test is done with the AM4-2023.02 xml obtained with the command below:

   git clone -b AM4_2023.02 http://gitlab.gfdl.noaa.gov/mdt/xml.git xml_2023.02

And the model codes are compiled and run on the ncrc5.intel22-classic-prod-openmp platform.

Note that both changes in FMScoupler and atmos_drivers need to be incorporated at the same time for the model to compile and run correctly.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [n/a] New check tests, if applicable, are included

