### PR TITLE
Split `update_atmos_radiation_physics` in `SHiELD/atmos_model.F90`

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -225,6 +225,9 @@ contains
 !   variable type are allocated for the global grid (without halo regions).
 ! </INOUT>
 subroutine update_atmos_radiation_physics(Atmos)
+!--- This subroutine, which merely combines calls to finer-grained subroutines,
+!    is only required for backwards compatibility with
+!    FMScoupler/SHiELD/coupler_main.F90.
   type (atmos_data_type), intent(in) :: Atmos
 
   call update_atmos_pre_radiation(Atmos)
@@ -300,12 +303,6 @@ subroutine update_atmos_pre_radiation (Atmos)
       type (atmos_data_type), intent(in) :: Atmos
 !--- local variables---
       integer :: nb, jdat(8), rc
-      integer :: nthrds
-#ifdef OPENMP
-      nthrds = omp_get_max_threads()
-#else
-      nthrds = 1
-#endif
 
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "radiation driver"
 !--- execute the IPD atmospheric radiation subcomponent (RRTM)
@@ -331,13 +328,6 @@ subroutine update_atmos_pre_radiation (Atmos)
       type (atmos_data_type), intent(in) :: Atmos
 !--- local variables---
       integer :: nb, jdat(8), rc
-      integer :: nthrds
-
-#ifdef OPENMP
-      nthrds = omp_get_max_threads()
-#else
-      nthrds = 1
-#endif
 
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "physics driver"
 !--- execute the IPD atmospheric physics step1 subcomponent (main physics driver)


### PR DESCRIPTION
**Description**

Per our discussion today, this surfaces what is discussed in #27 as a PR for greater visibility (marking as a draft for now pending possible overlapping work by @JosephMouallem).  It splits the `update_atmos_radiation_physics` subroutine into three parts:

- `update_atmos_pre_radiation`
- `update_atmos_radiation`
- `update_atmos_physics`

The `update_atmos_radiation_physics` subroutine is retained and does exactly what it did before (so this does not change answers and requires no downstream code changes), but is written in a more modular fashion, exposing its steps as additional public subroutines in `atmos_model_mod`.

Fixes #27

xref: https://github.com/ai2cm/fv3gfs-fortran/pull/317 for how we proceeded with this in FV3GFS.

**How Has This Been Tested?**

On top of the changes in #26, this has been tested in CI within the SHiELD-wrapper repository.  For the test configuration there, after these changes we get bit-for-bit identical results.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

