### PR TITLE
Enable outputting surface type fraction diagnostics from SHiELD

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -558,7 +558,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
    call gfdl_diag_register (Time, IPD_Data(:)%Sfcprop, IPD_Data(:)%IntDiag, IPD_Data%Cldprop, &
         Atm_block, Atmos%axes, IPD_Control%nfxr, IPD_Control%ldiag3d, &
         IPD_Control%nkld, IPD_Control%levs, IPD_Control%override_surface_radiative_fluxes)
-   call register_diag_manager_controlled_diagnostics(Time, IPD_Data(:)%IntDiag, Atm_block%nblks, Atmos%axes)
+   call register_diag_manager_controlled_diagnostics(Time, IPD_Data(:)%Sfcprop, IPD_Data(:)%IntDiag, Atm_block%nblks, Atmos%axes)
    if (Atm(mygrid)%coarse_graining%write_coarse_diagnostics) then
        call atmosphere_coarse_diag_axes(coarse_diagnostic_axes)
        call FV3GFS_diag_register_coarse(Time, coarse_diagnostic_axes)


### PR DESCRIPTION
**Description**

This small PR is required for compatibility with NOAA-GFDL/SHiELD_physics#36.  See the PR description there for more details regarding what this is for and how it was tested.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

