### PR TITLE
do_diss_est and dycore_only bugfixes

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -230,12 +230,16 @@ subroutine update_atmos_radiation_physics(Atmos)
 !    FMScoupler/SHiELD/coupler_main.F90.
   type (atmos_data_type), intent(in) :: Atmos
 
+  call mpp_clock_begin(shieldClock)
+
   call update_atmos_pre_radiation(Atmos)
 
   if (.not. dycore_only) then
     call update_atmos_radiation(Atmos)
     call update_atmos_physics(Atmos)
   end if
+
+  call mpp_clock_end(shieldClock)
 
 end subroutine update_atmos_radiation_physics
 
@@ -245,8 +249,6 @@ subroutine update_atmos_pre_radiation (Atmos)
 !--- local variables---
     integer :: nb, jdat(8)
     integer :: nthrds
-
-    call mpp_clock_begin(shieldClock)
 
 #ifdef OPENMP
     nthrds = omp_get_max_threads()
@@ -364,8 +366,6 @@ subroutine update_atmos_pre_radiation (Atmos)
       endif
       call getiauforcing(IPD_Control,IAU_data)
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "end of radiation and physics step"
-
-    call mpp_clock_end(shieldClock)
 
 !-----------------------------------------------------------------------
  end subroutine update_atmos_physics

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -43,7 +43,7 @@ module atmos_model_mod
 
 use mpp_mod,            only: mpp_pe, mpp_root_pe, mpp_clock_id, mpp_clock_begin
 use mpp_mod,            only: mpp_clock_end, CLOCK_COMPONENT, MPP_CLOCK_SYNC
-use mpp_mod,            only: mpp_min, mpp_max, mpp_error, mpp_chksum
+use mpp_mod,            only: mpp_min, mpp_max, mpp_error, mpp_chksum, NOTE
 use mpp_domains_mod,    only: domain2d
 use mpp_mod,            only: mpp_get_current_pelist_name
 use mpp_mod,            only: input_nml_file, stdlog, stdout
@@ -532,7 +532,12 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
    end if
 #endif
 
-   Atm(mygrid)%flagstruct%do_diss_est = IPD_Control%do_skeb
+   if (IPD_Control%do_skeb .and. .not. Atm(mygrid)%flagstruct%do_diss_est) then
+      call mpp_error(NOTE, "If using stochy physics (gfs_physics_nml::do_skeb = .T.) ")
+      call mpp_error(NOTE, "   a dissipation estimate must be provided.")
+      call mpp_error(NOTE, "   Setting fv_core_nml::do_diss_est=.T. to enable.")
+      Atm(mygrid)%flagstruct%do_diss_est = .true.
+   endif
 
 !  initialize the IAU module
    call iau_initialize (IPD_Control,IAU_data,Init_parm)

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -151,7 +151,7 @@ logical :: chksum_debug    = .false.
 logical :: dycore_only     = .false.
 logical :: debug           = .false.
 logical :: sync            = .false.
-logical :: first_time_step = .true.
+logical :: first_time_step = .false.
 logical :: fprint          = .true.
 real, dimension(4096) :: fdiag = 0. ! xic: TODO: this is hard coded, space can run out in some cases. Should make it allocatable.
 logical :: fdiag_override = .false. ! lmh: if true overrides fdiag and fhzer: all quantities are zeroed out after every calcluation, output interval and accumulation/avg/max/min are controlled by diag_manager, fdiag controls output interval only
@@ -627,7 +627,7 @@ subroutine update_atmos_model_state (Atmos)
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
     endif
-    if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. first_time_step) then
+    if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. (IPD_Control%kdt == 1 .and. first_time_step)) then
       if(Atmos%iau_offset > zero) then
         if( time_int - Atmos%iau_offset*3600. > zero ) then
           time_int = time_int - Atmos%iau_offset*3600.

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -730,8 +730,9 @@ subroutine update_atmos_model_state (Atmos)
 
       endif
 #endif
-      call gfdl_diag_output(Atmos%Time, Atm_block, IPD_Data, IPD_Control, fprint, &
-                            time_int, time_intfull, &
+      call gfdl_diag_output(Atmos%Time, Atm_block, IPD_Data, IPD_Control%nx, IPD_Control%ny, fprint, &
+                            IPD_Control%levs, 1, 1, 1.d0, time_int, time_intfull, &
+                            IPD_Control%fhswr, IPD_Control%fhlwr, &
                             mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0, &
                             Atm(mygrid)%coarse_graining%write_coarse_diagnostics,&
                             real(Atm(mygrid)%delp(is:ie,js:je,:), kind=kind_phys), &

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -698,9 +698,8 @@ subroutine update_atmos_model_state (Atmos)
 
       endif
 #endif
-      call gfdl_diag_output(Atmos%Time, Atm_block, IPD_Data, IPD_Control, IPD_Control%nx, IPD_Control%ny, fprint, &
-                            IPD_Control%levs, 1, 1, 1.d0, time_int, time_intfull, &
-                            IPD_Control%fhswr, IPD_Control%fhlwr, &
+      call gfdl_diag_output(Atmos%Time, Atm_block, IPD_Data, IPD_Control, fprint, &
+                            time_int, time_intfull, &
                             mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0, &
                             Atm(mygrid)%coarse_graining%write_coarse_diagnostics,&
                             real(Atm(mygrid)%delp(is:ie,js:je,:), kind=kind_phys), &

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -650,7 +650,7 @@ subroutine update_atmos_model_state (Atmos)
           time_intfull = time_intfull - Atmos%iau_offset*3600.
         endif
       endif
-      call gfdl_diag_output(Atmos%Time, Atm_block, IPD_Data, IPD_Control%nx, IPD_Control%ny, fprint, &
+      call gfdl_diag_output(Atmos%Time, Atm_block, IPD_Data, IPD_Control, IPD_Control%nx, IPD_Control%ny, fprint, &
                             IPD_Control%levs, 1, 1, 1.d0, time_int, time_intfull, &
                             IPD_Control%fhswr, IPD_Control%fhlwr, &
                             mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0, &


### PR DESCRIPTION
**Description**
Fixes two bugs:
- The `do_diss_est` flag would be hard-coded to equal `do_skeb`, meaning that this would never be enabled if stochastic physics were not turned on.
- SHiELD running with the option `dycore_only=.T.` would call `mpp_clock_begin(shieldClock)` but not `mpp_clock_end(shieldClock)` in each call to `update_atmos_pre_radiation()`, causing a FATAL error.

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration (e.g. compiler, OS).  Include
enough information so someone can reproduce your tests.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included

