### PR TITLE
Enable SHiELD simulations longer than ~68 years

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -695,12 +695,12 @@ subroutine update_atmos_model_state (Atmos)
     call get_time_seconds_int64(Atmos%Time - Atmos%Time_init, seconds)
 
     time_int = real(isec)
-    if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. (IPD_Control%kdt == 1 .and. first_time_step) ) then
+    if (ANY(nint(fdiag(:)*3600.0, kind=8) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0, kind=8)) .eq. 0) .or. (IPD_Control%kdt == 1 .and. first_time_step) ) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       if (mpp_pe() == mpp_root_pe()) write(6,*) ' gfs diags time since last bucket empty: ',time_int/3600.,'hrs'
       call atmosphere_nggps_diag(Atmos%Time)
     endif
-    if (ANY(nint(fdiag(:)*3600.0) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0)) .eq. 0) .or. (IPD_Control%kdt == 1 .and. first_time_step)) then
+    if (ANY(nint(fdiag(:)*3600.0, kind=8) == seconds) .or. (fdiag_fix .and. mod(seconds, nint(fdiag(1)*3600.0, kind=8)) .eq. 0) .or. (IPD_Control%kdt == 1 .and. first_time_step)) then
       if(Atmos%iau_offset > zero) then
         if( time_int - Atmos%iau_offset*3600. > zero ) then
           time_int = time_int - Atmos%iau_offset*3600.


### PR DESCRIPTION
**Description**

This PR implements the solution proposed in #35 to allow running SHiELD simulations for substantially longer than 68 years.  It is difficult to estimate a firm upper bound on what the simulation length can be now; if this were the only limitation then runs up to 5.8 million years could be completed, but there are likely other places where the model would fail first.  There is [another place](https://github.com/NOAA-GFDL/SHiELD_physics/blob/5e5e100c068d55b8247dcb428f9df36fb31bdf35/GFS_layer/GFS_driver.F90#L316) where seconds are used as a time unit to record the total length of the simulation, but there the time is recorded using a 64-bit floating point value, so we do risk overflow.

Fixes #35 

cc: @lharris4 

**How Has This Been Tested?**

I have tested this and confirmed that it does not change answers of existing simulations, and indeed allows us to run simulations longer than 68 years.  Out of curiosity, as a stress test, I also tried simulations with extremely large start dates—at some point in extremely long runs we also need to worry about the date in the simulation itself becoming large—a simulation starting in year 52,020 ran successfully, but a simulation starting in 200,000 crashed.  For the moment we probably want to be wary of simulations past 2100, however, due to a calendar mismatch between the coupler and the physics (NOAA-GFDL/FMSCoupler#103).


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

