### PR TITLE
Add diag_send_complete to the solo driver

### DIFF
--- a/solo/atmos_model.F90
+++ b/solo/atmos_model.F90
@@ -101,6 +101,7 @@ implicit none
          call fms_memutils_print_memuse_stats(text)
        endif
 
+       call fms_diag_send_complete(Time_step_atmos)
     enddo
 
     call fms_mpp_clock_end (id_loop)
@@ -296,6 +297,7 @@ contains
      call flush(stdout_unit)
    endif
 
+   call fms_diag_set_time_end(Time_end)
    call atmosphere_init (Time_init, Time, Time_step_atmos)
    call atmosphere_domain(atmos_domain)
 


### PR DESCRIPTION
**Description**
Adds a call to `diag_send_complete` to the solo driver so that it can work with the new diag manager

Fixes # (issue)

**How Has This Been Tested?**
SHiELD tests were ran by @abrooks1085 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

