### PR TITLE
Fix shieldclock crash in dycore_only

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -237,6 +237,7 @@ subroutine update_atmos_radiation_physics(Atmos)
     call update_atmos_physics(Atmos)
   end if
 
+   call mpp_clock_end(shieldClock)
 end subroutine update_atmos_radiation_physics
 
 subroutine update_atmos_pre_radiation (Atmos)
@@ -365,7 +366,6 @@ subroutine update_atmos_pre_radiation (Atmos)
       call getiauforcing(IPD_Control,IAU_data)
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "end of radiation and physics step"
 
-    call mpp_clock_end(shieldClock)
 
 !-----------------------------------------------------------------------
  end subroutine update_atmos_physics

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -230,6 +230,7 @@ subroutine update_atmos_radiation_physics(Atmos)
 !    FMScoupler/SHiELD/coupler_main.F90.
   type (atmos_data_type), intent(in) :: Atmos
 
+  call mpp_clock_begin(shieldClock)
   call update_atmos_pre_radiation(Atmos)
 
   if (.not. dycore_only) then
@@ -237,7 +238,7 @@ subroutine update_atmos_radiation_physics(Atmos)
     call update_atmos_physics(Atmos)
   end if
 
-   call mpp_clock_end(shieldClock)
+  call mpp_clock_end(shieldClock)
 end subroutine update_atmos_radiation_physics
 
 subroutine update_atmos_pre_radiation (Atmos)
@@ -246,8 +247,6 @@ subroutine update_atmos_pre_radiation (Atmos)
 !--- local variables---
     integer :: nb, jdat(8)
     integer :: nthrds
-
-    call mpp_clock_begin(shieldClock)
 
 #ifdef OPENMP
     nthrds = omp_get_max_threads()


### PR DESCRIPTION
shieldClock timer starts in update_atmos_pre_radiation and ends in update_atmos_physics.
This causes a crash when compiling shield and running with dycore_only since update_atmos_physics is not called in update_atmos_radiation_physics,  mpp_clock_begin is called again before calling mpp_clock_end.

In this commit both mpp_clock_begin and mpp_clock_end are moved to update_atmos_radiation_physics.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

