### PR TITLE
Surface radiation and precip fluxes exchange

### DIFF
--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -807,10 +807,10 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, do_concurrent_ra
 
 ! ensure sfc_coupled is properly set (needs to be true when using ocean coupling)
    if (fullcoupler_fluxes) then
-        if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "using ocean coupling - force sfc_coupled to be true"
+        if (mpp_pe() == mpp_root_pe()) print *, "using ocean coupling - enforce sfc_coupled in SHiELD phys to be true"
         IPD_Control%sfc_coupled = .true.
    else
-        if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "no ocean coupling - force sfc_coupled to be false"
+        if (mpp_pe() == mpp_root_pe()) print *, "no ocean coupling - enforce sfc_coupled in SHiELD phys to be false"
         IPD_Control%sfc_coupled = .false.
    endif
 

--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -452,7 +452,7 @@ subroutine update_atmos_model_radiation (Surface_boundary, Atmos) ! name change 
 ! subroutine update_atmos_radiation_physics (Atmos) !original
 ! SHiELD physics are run here
 !-----------------------------------------------------------------------
-  type (atmos_data_type), intent(in) :: Atmos
+  type (atmos_data_type), intent(inout) :: Atmos
   type(land_ice_atmos_boundary_type), intent(in) :: Surface_boundary
   ! dont know if Surface_boundary is needed here for the fluxes in shield, seems to be used as follow in am4
   ! AM4/src/atmos_phys/atmos_param/radiation/driver/radiation_driver.F90
@@ -481,16 +481,6 @@ subroutine update_atmos_model_radiation (Surface_boundary, Atmos) ! name change 
     call sfc_data_override (Atmos%Time, IPD_data, Atm_block, IPD_Control)
     call mpp_clock_end(overrideClock)
 
-!-----------------------------------------------------------------------------------
-!-----------------------------------------------------------------------------------
-!--- JOSEPH: do we override sfc here form ocean output before calling physics_step1
-    if (fullcoupler_fluxes) then
-    if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "apply_sfc_data_to_IPD"
-      call apply_sfc_data_to_IPD (Surface_boundary)
-    endif
-!-----------------------------------------------------------------------------------
-!-----------------------------------------------------------------------------------
-
 !--- if dycore only run, set up the dummy physics output state as the input state
     if (dycore_only) then
       do nb = 1,Atm_block%nblks
@@ -501,6 +491,12 @@ subroutine update_atmos_model_radiation (Surface_boundary, Atmos) ! name change 
       enddo
     else
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "setup step"
+
+!--- for atmos-ocean coupling: override selected surface fields in IPD (by joseph and kun)
+      if (fullcoupler_fluxes) then
+        if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "apply coupler sfc fields to IPD"
+        call apply_sfc_data_to_IPD (Surface_boundary)
+      endif
 
 !--- update IPD_Control%jdat(8)
       jdat(:) = 0
@@ -556,6 +552,12 @@ subroutine update_atmos_model_radiation (Surface_boundary, Atmos) ! name change 
       if (chksum_debug) then
         if (mpp_pe() == mpp_root_pe()) print *,'PHYSICS STEP1   ', IPD_Control%kdt, IPD_Control%fhour
         call FV3GFS_IPD_checksum(IPD_Control, IPD_Data, Atm_block)
+      endif
+
+!--- for atmos-ocean couplin g: apply sfc radiation and precip fluxes from IPD to Atmos data structure (by kun)
+      if (fullcoupler_fluxes) then
+        if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "apply fluxes from IPD to Atmos"
+        call apply_fluxes_from_IPD_to_Atmos (Atmos)
       endif
 
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "stochastic physics driver"
@@ -1123,6 +1125,92 @@ subroutine apply_sfc_data_to_IPD (Surface_boundary)
   enddo
 
 end subroutine apply_sfc_data_to_IPD
+! </SUBROUTINE>
+
+!#######################################################################
+! <SUBROUTINE NAME="apply_fluxes_from_IPD_to_Atmos">
+!
+! <OVERVIEW>
+! update Atmos variables
+! </OVERVIEW>
+
+! <DESCRIPTION>
+! apply surface shortwave, longwave, precip fluxes from SHiELD physics to Atmos data structure, 
+! which will be put on exchange grid in the coupler for other component models to use 
+! 
+! created by Kun Gao (kun.gao@noaa.gov)
+! 
+! </DESCRIPTION>
+
+! <TEMPLATE>
+!     call apply_fluxes_from_IPD_to_Atmos ( Atmos )
+! </TEMPLATE>
+
+subroutine apply_fluxes_from_IPD_to_Atmos ( Atmos )
+
+  type (atmos_data_type), intent(inout) :: Atmos
+  integer :: nb, blen, ix, i, j
+
+  real :: nirbmdi, visbmdi, nirbmui, visbmui
+  real :: nirdfdi, visdfdi, nirdfui, visdfui
+
+  do nb = 1,Atm_block%nblks
+     blen = Atm_block%blksz(nb)
+     do ix = 1, blen
+        i = Atm_block%index(nb)%ii(ix) - Atm_block%isc + 1
+        j = Atm_block%index(nb)%jj(ix) - Atm_block%jsc + 1
+
+        ! --- shortwave
+
+        ! eight sw components: dir/dif; nir/vis; down/up
+        nirbmdi = IPD_Data(nb)%Coupling%nirbmdi(ix)
+        nirdfdi = IPD_Data(nb)%Coupling%nirdfdi(ix)
+        visbmdi = IPD_Data(nb)%Coupling%visbmdi(ix)
+        visdfdi = IPD_Data(nb)%Coupling%visdfdi(ix)
+        nirbmui = IPD_Data(nb)%Coupling%nirbmui(ix)
+        nirdfui = IPD_Data(nb)%Coupling%nirdfui(ix)
+        visbmui = IPD_Data(nb)%Coupling%visbmui(ix)
+        visdfui = IPD_Data(nb)%Coupling%visdfui(ix)
+
+        ! cosine of zenith angle
+        Atmos%coszen(i,j) = IPD_Data(nb)%Radtend%coszen(ix)
+
+        ! visible down
+        Atmos%flux_sw_down_vis_dir(i,j) = visbmdi                         ! downward visible sw flux at surface - direct
+        Atmos%flux_sw_down_vis_dif(i,j) = visdfdi                         ! downward visible sw flux at surface - diffused
+
+        ! visible net
+        Atmos%flux_sw_vis_dir(i,j) = visbmdi - visbmui                    ! net (down-up) visible sw flux at surface - direct
+        Atmos%flux_sw_vis_dif(i,j) = visdfdi - visdfui                    ! net (down-up) visible sw flux at surface - diffused
+
+        ! total down
+        Atmos%flux_sw_down_total_dir(i,j) = nirbmdi + visbmdi             ! downward total sw flux at surface - direct
+        Atmos%flux_sw_down_total_dif(i,j) = nirdfdi + visdfdi             ! downward total sw flux at surface - diffused
+
+        ! total net
+        Atmos%flux_sw_dir(i,j) = (nirbmdi + visbmdi) - (nirbmui + visbmui)! net (down-up) sw flux at surface - direct
+        Atmos%flux_sw_dif(i,j) = (nirdfdi + visdfdi) - (nirdfui + visbmui)! net (down-up) sw flux at surface - diffused
+
+        ! total net and visible net; not used on exchange grid (not important)
+        Atmos%flux_sw(i,j)     = Atmos%flux_sw_dir(i,j) + Atmos%flux_sw_dif(i,j)
+        Atmos%flux_sw_vis(i,j) = Atmos%flux_sw_vis_dir(i,j) + Atmos%flux_sw_vis_dir(i,j)
+
+        ! --- longwave
+        ! total downward lw flux at sfc
+        Atmos%flux_lw(i,j) = IPD_Data(nb)%Radtend%sfcflw(ix)%dnfxc
+
+        ! --- precip rate (kg/m**2/s)
+        if ( IPD_Data(nb)%Sfcprop%srflag(ix) .lt. 0.5) then  ! rain (srflag = 0)
+          Atmos%lprec(i,j) = 1./IPD_Control%dtp * IPD_Data(nb)%Sfcprop%tprcp(ix)
+          Atmos%fprec(i,j) = 0.
+        else                                                 ! snow (srflag = 1)
+          Atmos%lprec(i,j) = 0.
+          Atmos%fprec(i,j) = 1./IPD_Control%dtp * IPD_Data(nb)%Sfcprop%tprcp(ix)
+        endif
+     enddo
+  enddo
+
+end subroutine apply_fluxes_from_IPD_to_Atmos
 ! </SUBROUTINE>
 
 !#######################################################################

--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -1118,6 +1118,8 @@ subroutine apply_sfc_data_to_IPD (Surface_boundary)
   type(land_ice_atmos_boundary_type), intent(in) :: Surface_boundary
   integer :: nb, blen, ix, i, j
 
+  !$OMP parallel do default(none) shared(Atm_block,IPD_Data,Surface_boundary) &
+  !$OMP                          private(blen,i,j)
   do nb = 1,Atm_block%nblks
      blen = Atm_block%blksz(nb)
      do ix = 1, blen
@@ -1171,6 +1173,9 @@ subroutine apply_fluxes_from_IPD_to_Atmos ( Atmos )
   real :: nirbmdi, visbmdi, nirbmui, visbmui
   real :: nirdfdi, visdfdi, nirdfui, visdfui
 
+  !$OMP parallel do default(none) shared(Atm_block,Atmos,IPD_Data,IPD_Control) &
+  !$OMP                          private(blen,i,j,nirbmdi,visbmdi,nirbmui,visbmui, &
+  !$OMP                                  nirdfdi,visdfdi,nirdfui,visdfui)
   do nb = 1,Atm_block%nblks
      blen = Atm_block%blksz(nb)
      do ix = 1, blen

--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -492,11 +492,15 @@ subroutine update_atmos_model_radiation (Surface_boundary, Atmos) ! name change 
     else
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "setup step"
 
-!--- for atmos-ocean coupling: override selected surface fields in IPD (by joseph and kun)
+!--------------------------------------------------------------------------------------------
+!--------------------------------------------------------------------------------------------
+!--- for atmos-ocean coupling: pass surface fluxes from coupler to SHiELD (by joseph and kun)
       if (fullcoupler_fluxes) then
-        if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "apply sfc fields from coupler to SHiELD"
+        if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "call apply_sfc_data_to_IPD"
         call apply_sfc_data_to_IPD (Surface_boundary)
       endif
+!--------------------------------------------------------------------------------------------
+!--------------------------------------------------------------------------------------------
 
 !--- update IPD_Control%jdat(8)
       jdat(:) = 0
@@ -554,11 +558,15 @@ subroutine update_atmos_model_radiation (Surface_boundary, Atmos) ! name change 
         call FV3GFS_IPD_checksum(IPD_Control, IPD_Data, Atm_block)
       endif
 
-!--- for atmos-ocean coupling: apply sfc radiation and precip fluxes from IPD to Atmos data structure (by kun)
+!--------------------------------------------------------------------------------------------
+!--------------------------------------------------------------------------------------------
+!--- for atmos-ocean coupling: pass rad and prec fluxes from IPD to Atmos structure (by kun)
       if (fullcoupler_fluxes) then
-        if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "apply sfc radiation and precip fluxes from IPD to Atmos"
+        if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "call apply_fluxes_from_IPD_to_Atmos"
         call apply_fluxes_from_IPD_to_Atmos (Atmos)
       endif
+!--------------------------------------------------------------------------------------------
+!--------------------------------------------------------------------------------------------
 
       if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "stochastic physics driver"
 !--- execute the IPD atmospheric physics step2 subcomponent (stochastic physics driver)


### PR DESCRIPTION
There are a few updates in the PR.

1.  A new procedure has been introduced to pass surface shortwave, longwave and precip fluxes from SHiELD physics to the coupler is introduced. Physical field exchange between atmosphere and ocean is now complete.
2. The procedure for passing surface air-sea fluxes to SHiELD physics has been moved within the "if dycore_only" switch.
3. Ensure that the "sfc_coupled" option in SHiELD physics is set correctly based on whether ocean coupling is used.