### PR TITLE
Fix model hang when writing intermediate restarts in SHiELDFULL nest experiment

### DIFF
--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -1287,6 +1287,7 @@ subroutine atmos_model_restart(Atmos, timestamp)
   type (atmos_data_type),   intent(inout) :: Atmos
   character(len=*),  intent(in)           :: timestamp
 
+    call set_atmosphere_pelist()
     call atmosphere_restart(timestamp)
     if (.not. dycore_only) then
        if (.not. Atmos%write_only_coarse_intermediate_restarts) then
@@ -1298,6 +1299,7 @@ subroutine atmos_model_restart(Atmos, timestamp)
                IPD_Control, Atmos%coarse_domain, timestamp)
        endif
     endif
+    call mpp_set_current_pelist() !should exit with global pelist to accomodate the full coupler atmos clock
 end subroutine atmos_model_restart
 ! </SUBROUTINE>
 


### PR DESCRIPTION
**Description**
In the `SHiELDFULL/atmos_model.F90` `atmos_model_restart` subroutine, I have added calls to `set_atmosphere_pelist` before writing restarts, and `mpp_set_current_pelist` after.  This gets us past a model hang when using a global nest configuration with SHiELDFULL.

Fixes # (issue)

**How Has This Been Tested?**
Tested on Gaea with a global nest SHiELD experiment provided to me by @kaiyuan-cheng 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

