### PR TITLE
Initialize gust for coupled shield

### DIFF
--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -1585,6 +1585,7 @@ end subroutine ice_atm_bnd_type_chksum
     Atmos % flux_sw_vis_dif         = 0.0
     Atmos % coszen                  = 0.0
     Atmos % tr_bot                  = 0.0 
+    Atmos % gust                    = 1.0 
 
   end subroutine alloc_atmos_data_type
 


### PR DESCRIPTION
For certain PE layouts, incorrect data was written to some fields on the exchange grid. Investigation revealed that the issue is caused by the `gust` variable not being initialized in the coupled SHiELD driver, even though it is used in `surface_flux.F90`.
In the coupled driver, `gust` is populated at a different stage in`atmos_model_init`, so that driver probably doesnt have this issue.