### PR TITLE
Bare minimum changes needed for SHiELDFULL coupler to compile with 2025.02-alpha1 (fmscoupler)

### DIFF
--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -177,6 +177,8 @@ end type surf_diff_type
      real, pointer, dimension(:,:) :: flux_sw_vis            =>null()
      real, pointer, dimension(:,:) :: flux_sw_vis_dir        =>null()
      real, pointer, dimension(:,:) :: flux_sw_vis_dif        =>null()
+     real, pointer, dimension(:,:,:) :: gex_atm2lnd          =>null()
+     real, pointer, dimension(:,:,:) :: gex_lnd2atm          =>null()
      real, pointer, dimension(:,:) :: flux_lw  => null() ! net longwave flux (W/m2) at the surface
      real, pointer, dimension(:,:) :: lprec    => null() ! mass of liquid precipitation since last time step (Kg/m2)
      real, pointer, dimension(:,:) :: fprec    => null() ! ass of frozen precipitation since last time step (Kg/m2)
@@ -250,6 +252,7 @@ type land_ice_atmos_boundary_type
    real, dimension(:,:),   pointer :: rough_heat     =>null() ! surface roughness (used for heat) ! kgao
    real, dimension(:,:),   pointer :: frac_open_sea  =>null() ! non-seaice fraction (%)
    real, dimension(:,:,:), pointer :: data           =>null() !collective field for "named" fields above
+   real, dimension(:,:,:), pointer :: gex_lnd2atm =>null() ! gex fields exchanged from lnd to atm
    integer                         :: xtype                   !REGRID, REDIST or DIRECT
 end type land_ice_atmos_boundary_type
 


### PR DESCRIPTION
**Description**
Bare minimum changes needed for SHiELDFULL/atmos_model.F90 so that SHiELD's shieldfull and shieldmom configurations can compile with FMScoupler 2025.02-alpha1

Fixes # (issue)

**How Has This Been Tested?**
Tested on Gaea with SHiELD_build tests

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

