### PR TITLE
Diag_manager fix for FMS modern diag_manager

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -51,7 +51,7 @@ use fms2_io_mod,        only: file_exists
 use fms_mod,            only: write_version_number
 use fms_mod,            only: clock_flag_default, error_mesg
 use fms_mod,            only: check_nml_error
-use diag_manager_mod,   only: diag_send_complete_instant
+use diag_manager_mod,   only: diag_send_complete
 use time_manager_mod,   only: time_type, get_time, get_date, &
                               operator(+), operator(-)
 use field_manager_mod,  only: MODEL_ATMOS
@@ -764,10 +764,10 @@ subroutine update_atmos_model_state (Atmos)
                             Atm(mygrid)%coarse_graining%write_coarse_diagnostics,&
                             real(Atm(mygrid)%delp(is:ie,js:je,:), kind=kind_phys), &
                             Atmos%coarsening_strategy, real(Atm(mygrid)%ptop, kind=kind_phys))
-      call diag_send_complete_instant (Atmos%Time)
       if (mod(isec,nint(3600*IPD_Control%fhzero)) == 0) diag_time = Atmos%Time
     endif
 
+    call diag_send_complete(Atmos%Time)
     call mpp_clock_end(diagClock)
     call mpp_clock_end(shieldClock)
 

--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -52,7 +52,7 @@ use fms2_io_mod,        only: file_exists
 use fms_mod,            only: write_version_number
 use fms_mod,            only: clock_flag_default, error_mesg
 use fms_mod,            only: check_nml_error
-use diag_manager_mod,   only: diag_send_complete_instant
+use diag_manager_mod,   only: diag_send_complete
 use time_manager_mod,   only: time_type, get_time, get_date, &
                               operator(+), operator(-)
 use field_manager_mod,  only: MODEL_ATMOS
@@ -1084,10 +1084,10 @@ subroutine update_atmos_model_state (Atmos)
                             Atm(mygrid)%coarse_graining%write_coarse_diagnostics,&
                             real(Atm(mygrid)%delp(is:ie,js:je,:), kind=kind_phys), &
                             Atmos%coarsening_strategy, real(Atm(mygrid)%ptop, kind=kind_phys))
-      call diag_send_complete_instant (Atmos%Time)
       if (mod(isec,nint(3600*IPD_Control%fhzero)) == 0) diag_time = Atmos%Time
     endif
 
+    call diag_send_complete(Atmos%Time_step)
     call mpp_clock_end(diagClock)
     call mpp_clock_end(shieldClock)
     call mpp_set_current_pelist() !should exit with global pelist to accomodate the full coupler atmos clock


### PR DESCRIPTION
**Description**
Updating atmos_model.F90 to use diag_send_complete which is required when using the modern diag magager from FMS.  Without this update, when you try to use the modern diag manager (in input.nml `diag_manager_nml: use_modern_diag = .T.`) the model crashes at runtime.
Fixes #55 

**How Has This Been Tested?**
Tested on Gaea:
ran with 64bit and 32 bit with and without modern diag manager.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

