### PR TITLE
change aliases for fms global module

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -49,8 +49,8 @@ use mpp_mod,            only: mpp_get_current_pelist_name
 use mpp_mod,            only: input_nml_file, stdlog, stdout
 use fms2_io_mod,        only: file_exists
 use fms_mod,            only: write_version_number
-use fms_mod,            only: clock_flag_default, error_mesg
-use fms_mod,            only: check_nml_error
+use fms_mod,            only: clock_flag_default, fms_error_mesg
+use fms_mod,            only: fms_check_nml_error
 use diag_manager_mod,   only: diag_send_complete_instant
 use time_manager_mod,   only: time_type, get_time, get_date, &
                               operator(+), operator(-)
@@ -446,7 +446,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, iau_offset)
 
    IF ( file_exists('input.nml')) THEN
       read(input_nml_file, nml=atmos_model_nml, iostat=io)
-      ierr = check_nml_error(io, 'atmos_model_nml')
+      ierr = fms_check_nml_error(io, 'atmos_model_nml')
    endif
 !-----------------------------------------------------------------------
    call atmosphere_resolution (nlon, nlat, global=.false.)

--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -49,8 +49,8 @@ use mpp_mod,            only: mpp_get_current_pelist_name
 use mpp_mod,            only: input_nml_file, stdlog, stdout
 use fms2_io_mod,        only: file_exists
 use fms_mod,            only: write_version_number
-use fms_mod,            only: clock_flag_default, fms_error_mesg
-use fms_mod,            only: fms_check_nml_error
+use fms_mod,            only: clock_flag_default
+use fms,                only: fms_check_nml_error, fms_error_mesg
 use diag_manager_mod,   only: diag_send_complete_instant
 use time_manager_mod,   only: time_type, get_time, get_date, &
                               operator(+), operator(-)

--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -50,8 +50,8 @@ use mpp_mod,            only: mpp_get_current_pelist_name, mpp_set_current_pelis
 use mpp_mod,            only: input_nml_file, stdlog, stdout
 use fms2_io_mod,        only: file_exists
 use fms_mod,            only: write_version_number
-use fms_mod,            only: clock_flag_default, fms_error_mesg
-use fms_mod,            only: fms_check_nml_error
+use fms_mod,            only: clock_flag_default
+use fms,                only: fms_check_nml_error, fms_error_mesg
 use diag_manager_mod,   only: diag_send_complete_instant
 use time_manager_mod,   only: time_type, get_time, get_date, &
                               operator(+), operator(-)

--- a/SHiELDFULL/atmos_model.F90
+++ b/SHiELDFULL/atmos_model.F90
@@ -50,8 +50,8 @@ use mpp_mod,            only: mpp_get_current_pelist_name, mpp_set_current_pelis
 use mpp_mod,            only: input_nml_file, stdlog, stdout
 use fms2_io_mod,        only: file_exists
 use fms_mod,            only: write_version_number
-use fms_mod,            only: clock_flag_default, error_mesg
-use fms_mod,            only: check_nml_error
+use fms_mod,            only: clock_flag_default, fms_error_mesg
+use fms_mod,            only: fms_check_nml_error
 use diag_manager_mod,   only: diag_send_complete_instant
 use time_manager_mod,   only: time_type, get_time, get_date, &
                               operator(+), operator(-)
@@ -730,7 +730,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, do_concurrent_ra
 
    IF ( file_exists('input.nml')) THEN
       read(input_nml_file, nml=atmos_model_nml, iostat=io)
-      ierr = check_nml_error(io, 'atmos_model_nml')
+      ierr = fms_check_nml_error(io, 'atmos_model_nml')
    endif
 !-----------------------------------------------------------------------
    call get_number_tracers(MODEL_ATMOS, num_tracers=ntracers)

--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -46,10 +46,10 @@ use mpp_mod,            only: mpp_clock_end, CLOCK_COMPONENT, mpp_error, mpp_chk
 use mpp_mod,            only: mpp_set_current_pelist, mpp_get_current_pelist, mpp_npes
 use mpp_domains_mod,    only: domain2d, mpp_get_ntile_count
 use mpp_mod,            only: input_nml_file
-use fms_mod,            only: fms_error_mesg, FATAL, NOTE, WARNING
+use fms_mod,            only: FATAL, NOTE, WARNING
 use fms_mod,            only: write_version_number, stdlog, stdout
 use fms_mod,            only: clock_flag_default
-use fms_mod,            only: fms_check_nml_error
+use fms,                only: fms_check_nml_error, fms_error_mesg
 use fms2_io_mod,        only: FmsNetcdfFile_t, FmsNetcdfDomainFile_t, &
                               register_restart_field, register_axis, unlimited, &
                               open_file, read_restart, write_restart, close_file, &

--- a/coupled/atmos_model.F90
+++ b/coupled/atmos_model.F90
@@ -46,10 +46,10 @@ use mpp_mod,            only: mpp_clock_end, CLOCK_COMPONENT, mpp_error, mpp_chk
 use mpp_mod,            only: mpp_set_current_pelist, mpp_get_current_pelist, mpp_npes
 use mpp_domains_mod,    only: domain2d, mpp_get_ntile_count
 use mpp_mod,            only: input_nml_file
-use fms_mod,            only: error_mesg, FATAL, NOTE, WARNING
+use fms_mod,            only: fms_error_mesg, FATAL, NOTE, WARNING
 use fms_mod,            only: write_version_number, stdlog, stdout
 use fms_mod,            only: clock_flag_default
-use fms_mod,            only: check_nml_error
+use fms_mod,            only: fms_check_nml_error
 use fms2_io_mod,        only: FmsNetcdfFile_t, FmsNetcdfDomainFile_t, &
                               register_restart_field, register_axis, unlimited, &
                               open_file, read_restart, write_restart, close_file, &
@@ -791,7 +791,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, &
 
    IF ( file_exists('input.nml')) THEN
       read(input_nml_file, nml=atmos_model_nml, iostat=io)
-      ierr = check_nml_error(io, 'atmos_model_nml')
+      ierr = fms_check_nml_error(io, 'atmos_model_nml')
    endif
    do_netcdf_restart = .true. !< Always use netcdf
 
@@ -799,12 +799,12 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, &
 ! how many tracers have been registered?
 !  (will print number below)
    call get_number_tracers ( MODEL_ATMOS, ntrace, ntprog, ntdiag, ntfamily )
-   if ( ntfamily > 0 ) call error_mesg ('atmos_model', 'ntfamily > 0', FATAL)
+   if ( ntfamily > 0 ) call fms_error_mesg ('atmos_model', 'ntfamily > 0', FATAL)
    ivapor = get_tracer_index( MODEL_ATMOS, 'sphum' )
    if (ivapor==NO_TRACER) &
         ivapor = get_tracer_index( MODEL_ATMOS, 'mix_rat' )
    if (ivapor==NO_TRACER) &
-        call error_mesg('atmos_model_init', 'Cannot find water vapor in ATM tracer table', FATAL)
+        call fms_error_mesg('atmos_model_init', 'Cannot find water vapor in ATM tracer table', FATAL)
 
 !-----------------------------------------------------------------------
 ! initialize atmospheric model -----
@@ -947,7 +947,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, &
    endif
 
    if (atm_restart_exist .or. til_restart_exist) then
-       if (ipts /= mlon .or. jpts /= mlat) call error_mesg &
+       if (ipts /= mlon .or. jpts /= mlat) call fms_error_mesg &
                ('coupled_atmos_init', 'incorrect resolution on restart file', WARNING)
 
 !---- if the time step has changed then convert ----

--- a/solo/atmos_model.F90
+++ b/solo/atmos_model.F90
@@ -148,7 +148,7 @@ contains
 !----- read namelist -------
 
    read (fms_mpp_input_nml_file, nml=main_nml, iostat=io)
-   ierr = check_nml_error(io, 'main_nml')
+   ierr = fms_check_nml_error(io, 'main_nml')
 
 !----- write namelist to logfile -----
 
@@ -156,7 +156,7 @@ contains
    if ( fms_mpp_pe() == fms_mpp_root_pe() ) write (logunit, nml=main_nml)
 
    if (dt_atmos == 0) then
-     call error_mesg ('program atmos_model', 'dt_atmos has not been specified', FATAL)
+     call fms_error_mesg ('program atmos_model', 'dt_atmos has not been specified', FATAL)
    endif
 
    if(fms_mpp_lowercase(calendar) == 'no_calendar') then
@@ -170,7 +170,7 @@ contains
    else if(fms_mpp_lowercase(calendar) == 'gregorian') then
      calendartype = GREGORIAN
    else
-     call error_mesg ('program atmos_model', trim(calendar)//' is an invalid value for calendar', FATAL)
+     call fms_error_mesg ('program atmos_model', trim(calendar)//' is an invalid value for calendar', FATAL)
    endif
    call fms_time_manager_set_calendar_type(calendartype)
 
@@ -277,13 +277,13 @@ contains
 !-----------------------------------------------------------------------
 !----- initial (base) time must not be greater than current time -----
 
-   if ( Time_init > Time ) call error_mesg ('program atmos_model',  &
+   if ( Time_init > Time ) call fms_error_mesg ('program atmos_model',  &
                    'initial time is greater than current time', FATAL)
 
 !----- make sure run length is a multiple of atmos time step ------
 
    if ( num_atmos_calls * Time_step_atmos /= Run_length )  &
-        call error_mesg ('program atmos_model',  &
+        call fms_error_mesg ('program atmos_model',  &
            'run length must be multiple of atmosphere time step', FATAL)
 
 !-----------------------------------------------------------------------
@@ -343,7 +343,7 @@ contains
 
 !----- check time versus expected ending time ----
 
-      if (Time /= Time_end) call error_mesg ('program atmos_model',  &
+      if (Time /= Time_end) call fms_error_mesg ('program atmos_model',  &
               'final time does not match expected ending time', WARNING)
 
 !----- write restart file ------


### PR DESCRIPTION
**Description**
updates the `error_mesg` and `check_nml_error` routines to use the fms prefix

Fixes # (issue)

**How Has This Been Tested?**
compiled aquaplanet with this branch + my updates for FMS and the coupler 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included

