### PR TITLE
Update seawater mask used for MOM6 fluxes

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -1149,7 +1149,7 @@ subroutine apply_sfc_data_to_IPD (Surface_boundary)
         !       lhflx over valid ocean points will be updated below with physical values
         !IPD_Data(nb)%Sfcprop%lhflx(ix) = -999
 
-        if (nint(IPD_Data(nb)%Sfcprop%slmsk(ix)) == 0 .and. &
+        if ( Surface_boundary%frac_open_sea(i,j) .gt. 0.999999 .and. &
                  Surface_boundary%rough_mom(i,j) .gt. 1e-9) then ! .and. &
                  !Surface_boundary%rough_heat(i,j) .gt. 1e-9 .and. &
                  !Surface_boundary%u_star(i,j) .lt. 10 .and. &


### PR DESCRIPTION
The if-statement condition used for the two-way coupling from the ocean to the atmosphere is now updated to use the quantity `Surface_boundary%frac_open_sea` from the coupler instead of `Sfcprop%slmsk` which represents SHiELD land mask.
This change addresses issues observed at coastlines where a SHiELD land mask value of 0 does not necessarily prevent updates to data corresponding to fractional land points from the land null component via the coupler.
Utilizing `frac_open_sea` will enforce the condition that the fluxes are applied only over fully ocean-covered points.