### PR TITLE
Enable concurrent coupling

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -592,7 +592,7 @@ subroutine update_atmos_model_radiation (Surface_boundary, Atmos) ! name change 
     endif
 
     call mpp_clock_end(shieldClock)
-    call mpp_set_current_pelist(Atmos%pelist) !should exit with global pelist to accomodate the full coupler atmos clock
+    call mpp_set_current_pelist(Atmos%pelist, no_sync=.TRUE.) !should exit with global pelist to accomodate the full coupler atmos clock
 
 !-----------------------------------------------------------------------
  !end subroutine update_atmos_radiation_physics
@@ -943,7 +943,7 @@ subroutine atmos_model_init (Atmos, Time_init, Time, Time_step, do_concurrent_ra
                             Atmos % lon_bnd(:,:),  &
                             Atmos % lat_bnd(:,:), Atmos % area)
 
-   call mpp_set_current_pelist(Atmos%pelist) !should exit with global pelist to accomodate the full coupler atmos clock
+   call mpp_set_current_pelist(Atmos%pelist, no_sync=.TRUE.) !should exit with global pelist to accomodate the full coupler atmos clock
 
 end subroutine atmos_model_init
 ! </SUBROUTINE>
@@ -969,7 +969,7 @@ subroutine update_atmos_model_dynamics (Atmos)
     call mpp_clock_begin(fv3Clock)
     call atmosphere_dynamics (Atmos%Time)
     call mpp_clock_end(fv3Clock)
-    call mpp_set_current_pelist(Atmos%pelist) !should exit with global pelist to accomodate the full coupler atmos clock
+    call mpp_set_current_pelist(Atmos%pelist, no_sync=.TRUE.) !should exit with global pelist to accomodate the full coupler atmos clock
 
 end subroutine update_atmos_model_dynamics
 ! </SUBROUTINE>
@@ -1101,7 +1101,7 @@ subroutine update_atmos_model_state (Atmos)
     call diag_send_complete(Atmos%Time_step)
     call mpp_clock_end(diagClock)
     call mpp_clock_end(shieldClock)
-    call mpp_set_current_pelist(Atmos%pelist) !should exit with global pelist to accomodate the full coupler atmos clock
+    call mpp_set_current_pelist(Atmos%pelist, no_sync=.TRUE.) !should exit with global pelist to accomodate the full coupler atmos clock
 
  end subroutine update_atmos_model_state
 ! </SUBROUTINE>
@@ -1330,7 +1330,7 @@ subroutine atmos_model_restart(Atmos, timestamp)
                IPD_Control, Atmos%coarse_domain, timestamp)
        endif
     endif
-    call mpp_set_current_pelist(Atmos%pelist) !should exit with global pelist to accomodate the full coupler atmos clock
+    call mpp_set_current_pelist(Atmos%pelist, no_sync=.TRUE.) !should exit with global pelist to accomodate the full coupler atmos clock
 end subroutine atmos_model_restart
 ! </SUBROUTINE>
 


### PR DESCRIPTION
This PR enables coupled SHiELD's concurrent coupling.
Atmosphere code blocks running on atmospheric PEs, `atm%pe`, should exit explicitly with the pelist associated with the full atmosphere `Atmos%pelist`, otherwise, it will exit with all pes (atmos+ocn) and cause a crash related to the coupler clocks (as all PEs will be called for an mpp_clock_end of an atmosphere code block.)
This does not break the nesting code where atm(n)%pelist are allocated separately.
Nesting with serial/concurrent coupling in the full coupled model is yet to be tested.

