### PR TITLE
Full coupler fluxes

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -385,9 +385,11 @@ if (fullcoupler_fluxes == 0) then
   ! do nothing
 else
   if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "call apply_sfc_data_to_IPD"
-  if (fullcoupler_fluxes == 1) then ! Only consider full coupler fluxes from ocean points - exclude land points (for SHiELD+MOM6)
+  ! Only consider full coupler fluxes from ocean points - exclude land points (for SHiELD+MOM6)
+  if (fullcoupler_fluxes == 1) then
     call apply_sfc_data_to_IPD (Surface_boundary, ocean_points_only=.true.)
-  elseif (fullcoupler_fluxes == 2) then ! Take all fluxes from the coupler ocean and land points (for the fully coupled model with LM4)
+  ! Take all fluxes from the coupler ocean and land points (for the fully coupled model with LM4)
+  elseif (fullcoupler_fluxes == 2) then
     call apply_sfc_data_to_IPD (Surface_boundary, ocean_points_only=.false.)
   else
     call mpp_error(FATAL, "Invalid option for fullcoupler_fluxes, should be 0, 1, or 2 check atmos_model.F90 for more info")
@@ -528,9 +530,11 @@ if (fullcoupler_fluxes == 0) then
   ! do nothing
 else
   if (mpp_pe() == mpp_root_pe() .and. debug) write(6,*) "call apply_sfc_data_to_IPD"
-  if (fullcoupler_fluxes == 1) then ! Only consider full coupler fluxes from ocean points - exclude land points (for SHiELD+MOM6)
+  ! Only consider full coupler fluxes from ocean points - exclude land points (for SHiELD+MOM6)
+  if (fullcoupler_fluxes == 1) then
     call apply_sfc_data_to_IPD (Surface_boundary, ocean_points_only=.true.)
-  elseif (fullcoupler_fluxes == 2) then ! Take all fluxes from the coupler ocean and land points (for the fully coupled model with LM4)
+  ! Take all fluxes from the coupler ocean and land points (for the fully coupled model with LM4)
+  elseif (fullcoupler_fluxes == 2) then
     call apply_sfc_data_to_IPD (Surface_boundary, ocean_points_only=.false.)
   else
     call mpp_error(FATAL, "Invalid option for fullcoupler_fluxes, should be 0, 1, or 2 check atmos_model.F90 for more info")


### PR DESCRIPTION
Rewrite the logic when using the fluxes from the full coupler to accommodate all configurations for SHiELD, SHiELD_MOM6, SHiELD_MOM6_LM4, the `fullcoupler_fluxes` is now an integer with three available options:
- 0: no fluxes from the fullcoupler to the physics
- 1: only use the full coupler fluxes over ocean points, for SHiELD_MOM6 coupling
- 2: use fluxes over ocean and land points (all points), for SHiELD_MOM6_LM4 coupling.

Depends on: 
- atmos_driver #64 
- SHiELD_physics [#70](https://github.com/NOAA-GFDL/SHiELD_physics/pull/70), [#71](https://github.com/NOAA-GFDL/SHiELD_physics/pull/71), [#72](https://github.com/NOAA-GFDL/SHiELD_physics/pull/72)
